### PR TITLE
More tests for simple regexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "keywords": ["regex", "regexp", "regular", "expression", "pattern", "definition", "composition", "subexpression", "combination"],
     "author": "Aadit M Shah (http://aaditmshah.github.com/) <aaditmshah@fastmail.fm>",
     "main": "lib/regex.js",
+    "scripts": {
+        "test": "node tests/regex.js"
+    },
     "maintainers": [{
         "name": "Aadit M Shah",
         "email": "aaditmshah@fastmail.fm",

--- a/tests/regex.js
+++ b/tests/regex.js
@@ -1,12 +1,18 @@
 var Regex = require("..");
 
 var regex = new Regex(/(a|b)*abb/);
+var regex2 = new Regex(/[a-b]*abb/);
+var regex3 = new Regex(/.*abb/);
+var regex4 = new Regex(/.*/);
 
 if (regex.test("abb") &&
     regex.test("aabb") &&
     regex.test("babb") &&
     regex.test("aaabb") &&
     regex.test("ababb") &&
+    regex2.test("aabb") &&
+    regex3.test("aabb") &&
+    regex4.test("aabb") &&
     !regex.test("abba") &&
     !regex.test("cabb")) console.log("Passed all tests.");
 else {


### PR DESCRIPTION
The only regex that was tested right now was: `/(a|b)*abb/`
I added new regexes: `/[a-b]*abb/`, `/.*abb/` and `/.*/`
Those new ones should match every pattern that the first one is matching but they don't.
See issue #4 and [this question](http://stackoverflow.com/questions/40653850/npm-package-regex-doesnt-work-with-the-simple-regular-expression) on Stack Overflow.
I think this PR should be accepted to have tests that should help to fix that issue.